### PR TITLE
fix: updated qnorm documentation and test design - feedback addressed by Jason Lee

### DIFF
--- a/src/pystats_norm/qnorm.py
+++ b/src/pystats_norm/qnorm.py
@@ -11,7 +11,7 @@ def qnorm(p, mean=0, sd=1, lower_tail=True):
     Parameters
     ----------
     p: np.float64
-        The probability for which to find the quantile.
+        The probability for which to find the quantile. p must be between 0 and 1 (exclusive).
 
     mean: np.float64, optional
         The mean (average) of the normal distribution. Default is 0.

--- a/src/pystats_norm/qnorm.py
+++ b/src/pystats_norm/qnorm.py
@@ -10,13 +10,13 @@ def qnorm(p, mean=0, sd=1, lower_tail=True):
 
     Parameters
     ----------
-    p: np.float
+    p: np.float64
         The probability for which to find the quantile. Must be between 0 and 1 (exclusive).
 
-    mean: np.float, optional
+    mean: np.float64, optional
         The mean (average) of the normal distribution. Default is 0.
         
-    sd: np.float, optional
+    sd: np.float64, optional
         The standard deviation of the normal distribution. Default is 1.
 
     lower_tail: bool, optional
@@ -26,7 +26,7 @@ def qnorm(p, mean=0, sd=1, lower_tail=True):
         
     Returns
     -------
-    np.float
+    np.float64
         Returns the value of the inverse cumulative density function (cdf) of the normal distribution 
         given a certain random variable p, a population mean μ, and the population standard deviation σ.
 

--- a/src/pystats_norm/qnorm.py
+++ b/src/pystats_norm/qnorm.py
@@ -10,13 +10,13 @@ def qnorm(p, mean=0, sd=1, lower_tail=True):
 
     Parameters
     ----------
-    p: np.float64
-        The probability for which to find the quantile. p must be between 0 and 1 (exclusive).
+    p: np.float
+        The probability for which to find the quantile. Must be between 0 and 1 (exclusive).
 
-    mean: np.float64, optional
+    mean: np.float, optional
         The mean (average) of the normal distribution. Default is 0.
         
-    std_dev: np.float64, optional
+    sd: np.float, optional
         The standard deviation of the normal distribution. Default is 1.
 
     lower_tail: bool, optional
@@ -26,7 +26,7 @@ def qnorm(p, mean=0, sd=1, lower_tail=True):
         
     Returns
     -------
-    np.float64
+    np.float
         Returns the value of the inverse cumulative density function (cdf) of the normal distribution 
         given a certain random variable p, a population mean μ, and the population standard deviation σ.
 

--- a/tests/test_qnorm.py
+++ b/tests/test_qnorm.py
@@ -17,7 +17,9 @@ def test_output_datatype():
             (0.95, 0, 1, True, norm.ppf(0.95)),
             (0.95, 0, 1, False, norm.isf(0.95)),
             (0.99, 0, 1, True, norm.ppf(0.99)),
-            (0.99, 0, 1, False, norm.isf(0.99))
+            (0.99, 0, 1, False, norm.isf(0.99)),
+            (0.99, 10, 5, True, norm.ppf(0.99, 10, 5)),
+            (0.99, 10, 5, False, norm.isf(0.99, 10, 5))
         ]
 )
 def test_normal_cases(p, mean, sd, lower_tail, expected, tol=1e-6):


### PR DESCRIPTION
1. Function documentation: 
- Updated parameter to np.float64 to align with other functions
- Parameter "std_dev" updated to "sd" to align with the function
- Parameter "p" is now explicitly stated that it must be between 0 and 1 (exclusive).

2. Test design: 
- Added test cases for qnorm with varying values for mean and std_dev